### PR TITLE
Modify expected point format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+A fork of Simplify.js, modified to expect an array of points in a [x, y] format.
+
+---
+
 Simplify.js is a high-performance JavaScript polyline simplification library by Vladimir Agafonkin, extracted from [Leaflet](http://leafletjs.com).
 
 Checkout the demo with docs: http://mourner.github.io/simplify-js/

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-type Point = [number, number];
+type Point = [x: number, y: number];
 
 declare function simplify<T extends Point>(points: T[], tolerance?: number, highQuality?: boolean): T[];
 declare namespace simplify {}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,4 @@
-interface Point {
-	x: number;
-	y: number;
-}
+type Point = [number, number];
 
 declare function simplify<T extends Point>(points: T[], tolerance?: number, highQuality?: boolean): T[];
 declare namespace simplify {}

--- a/simplify.js
+++ b/simplify.js
@@ -6,14 +6,14 @@
 
 (function () { 'use strict';
 
-// to suit your point format, run search/replace for '.x' and '.y';
+// to suit your point format, run search/replace for '[0]' and '[1]';
 // for 3D version, see 3d branch (configurability would draw significant performance overhead)
 
 // square distance between 2 points
 function getSqDist(p1, p2) {
 
-    var dx = p1.x - p2.x,
-        dy = p1.y - p2.y;
+    var dx = p1[0] - p2[0],
+        dy = p1[1] - p2[1];
 
     return dx * dx + dy * dy;
 }
@@ -21,18 +21,18 @@ function getSqDist(p1, p2) {
 // square distance from a point to a segment
 function getSqSegDist(p, p1, p2) {
 
-    var x = p1.x,
-        y = p1.y,
-        dx = p2.x - x,
-        dy = p2.y - y;
+    var x = p1[0],
+        y = p1[1],
+        dx = p2[0] - x,
+        dy = p2[1] - y;
 
     if (dx !== 0 || dy !== 0) {
 
-        var t = ((p.x - x) * dx + (p.y - y) * dy) / (dx * dx + dy * dy);
+        var t = ((p[0] - x) * dx + (p[1] - y) * dy) / (dx * dx + dy * dy);
 
         if (t > 1) {
-            x = p2.x;
-            y = p2.y;
+            x = p2[0];
+            y = p2[1];
 
         } else if (t > 0) {
             x += dx * t;
@@ -40,8 +40,8 @@ function getSqSegDist(p, p1, p2) {
         }
     }
 
-    dx = p.x - x;
-    dy = p.y - y;
+    dx = p[0] - x;
+    dy = p[1] - y;
 
     return dx * dx + dy * dy;
 }


### PR DESCRIPTION
This PR modifies the `simplify` function to expect points in [number, number][] format, rather than {x: number, y: number}[] format.